### PR TITLE
Fix size of output

### DIFF
--- a/src/main/java/net/imglib2/ops/operation/img/unary/ImgRotate2D.java
+++ b/src/main/java/net/imglib2/ops/operation/img/unary/ImgRotate2D.java
@@ -134,7 +134,7 @@ public class ImgRotate2D< T extends Type< T > & Comparable< T >> implements Unar
 		long[] dims = new long[ min.length ];
 		for ( int i = 0; i < dims.length; i++ )
 		{
-			dims[ i ] = max[ i ] - min[ i ];
+			dims[ i ] = max[ i ] - min[ i ] + 1;
 		}
 
 		return op.factory().create( new FinalInterval( dims ), op.randomAccess().get().createVariable() );


### PR DESCRIPTION
In order to get a FinalInterval with `min=min` and `max=max`, we have to create it with `dims = max - min + 1`.

See https://github.com/knime-ip/knip/issues/499.